### PR TITLE
Fixes to Makefile and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ all : tests
 # Is there a build tool for Agda that tracks dependencies?
 
 # Compile unconditionally
-compile:
+Test:
 	agda --compile Test.agda
+
+compile: Test
 
 tests: Test
 	./Test
@@ -20,3 +22,6 @@ listings:
 	@mkdir -p html
 	agda -i. --html Everything.agda
 
+
+clean:
+	rm -f Test

--- a/Test.agda
+++ b/Test.agda
@@ -16,6 +16,8 @@ open import Symbolic.Extrinsic
 open import Symbolic.StackProg
 open import Dot
 
+open import Data.Product using (_,_)
+
 -- open CartUtils
 
 open TyUtils

--- a/Test.agda
+++ b/Test.agda
@@ -18,8 +18,6 @@ open import Symbolic.Extrinsic
 open import Symbolic.StackProg
 open import Dot
 
-open import Data.Product using (_,_)
-
 -- open CartUtils
 
 open TyUtils

--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,21 @@
+## Introduction
+
 This Agda project plays with composable Mealy machines with compositional/functorial semantics to generate computational hardware.
+
+## Dependencies
 
 Circuit graph rendering requires [GraphViz](https://graphviz.org/).
 
 https://github.com/agda/agda/issues/3619
+
+## Building
 
 Makefile targets:
 
 *   `compile`: compiles the `Test` module, though doing so faster from within the Emacs mode (`∁-c C­x C-C`).
 *   `tests`: generates circuit diagrams in the `Figures` subdirectory (dot files and their PDF renderings).
 
-
-If you get an error message "`Could not find module ‘Numeric.IEEE’`", then there is one Haskell package you need to have installed:
-```
-cabal v1-install ieee754
-```
+## Summary of important modules
 
 A quick summary of the important modules:
 
@@ -38,3 +40,26 @@ A quick summary of the important modules:
 
 There are many semantic functions (`⟦_⟧`) mapping between categories.
 Every one of them should be functorial, which is to say that the representation faithfully implements its meaning.
+
+## Troubleshooting
+
+If you get an error message "`Could not find module ‘Numeric.IEEE’`", then there is one Haskell package you need to have installed:
+```
+cabal v2-install ieee754
+```
+
+```
+Calling: ghc -O -o /Users/sseefried/code/agda-machines/Test -Werror -i/Users/sseefried/code/agda-machines -main-is MAlonzo.Code.Test /Users/sseefried/code/agda-machines/MAlonzo/Code/Test.hs --make -fwarn-incomplete-patterns -fno-warn-overlapping-patterns
+[  1 of 153] Compiling MAlonzo.RTE      ( MAlonzo/RTE.hs, MAlonzo/RTE.o )
+Compilation error:
+
+MAlonzo/RTE.hs:9:1: error:
+    Could not find module ‘Numeric.IEEE’
+    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
+  |
+9 | import Numeric.IEEE ( IEEE(identicalIEEE, nan) )
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+You can find out how to more about how to solve this problem [here](https://agda.readthedocs.io/en/latest/getting-started/installation.html)
+under the heading "Installing the agda and agda-mode programs".

--- a/readme.md
+++ b/readme.md
@@ -43,10 +43,7 @@ Every one of them should be functorial, which is to say that the representation 
 
 ## Troubleshooting
 
-If you get an error message "`Could not find module ‘Numeric.IEEE’`", then there is one Haskell package you need to have installed:
-```
-cabal v2-install ieee754
-```
+You might see an error message like this:
 
 ```
 Calling: ghc -O -o /Users/sseefried/code/agda-machines/Test -Werror -i/Users/sseefried/code/agda-machines -main-is MAlonzo.Code.Test /Users/sseefried/code/agda-machines/MAlonzo/Code/Test.hs --make -fwarn-incomplete-patterns -fno-warn-overlapping-patterns
@@ -61,5 +58,10 @@ MAlonzo/RTE.hs:9:1: error:
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
-You can find out how to more about how to solve this problem [here](https://agda.readthedocs.io/en/latest/getting-started/installation.html)
-under the heading "Installing the agda and agda-mode programs".
+You can fix this with:
+
+```
+cabal v2-install ieee754
+```
+
+You can find out how to more about how to solve this problem [here](https://agda.readthedocs.io/en/latest/getting-started/installation.html#installing-the-agda-and-the-agda-mode-programs).

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ https://github.com/agda/agda/issues/3619
 
 Makefile targets:
 
-*   `compile`: compiles the `Test` module, though doing so faster from within the Emacs mode (`∁-c C­x C-C`).
+*   `compile`: compiles the `Test` module, but you can compile faster from within the Emacs mode (`∁-c C­x C-C`).
 *   `tests`: generates circuit diagrams in the `Figures` subdirectory (dot files and their PDF renderings).
 
 ## Summary of important modules


### PR DESCRIPTION
Apart from adding some documentation to the README I've added a `Test` target and then had `compile` refer to that target. 

I did this because when I did `make tests` from a clean repo it didn't work saying:

```
make: *** No rule to make target `Test', needed by `tests'.  Stop.
```